### PR TITLE
SDK improvements

### DIFF
--- a/packages/data/src/events/events.ts
+++ b/packages/data/src/events/events.ts
@@ -248,6 +248,11 @@ export type CrcV2_DiscountCost = CirclesBaseEvent & {
   cost?: bigint;
 };
 
+export type Crc_UnknownEvent = CirclesBaseEvent & {
+  $event: 'Crc_UnknownEvent';
+  originalEventType: string;
+};
+
 export type CirclesEvent =
   | CrcV1_HubTransfer
   | CrcV1_Signup
@@ -281,7 +286,8 @@ export type CirclesEvent =
   | CrcV2_DepositInflationary
   | CrcV2_WithdrawDemurraged
   | CrcV2_WithdrawInflationary
-  | CrcV2_DiscountCost;
+  | CrcV2_DiscountCost
+  | Crc_UnknownEvent;
 
 export type CirclesEventType =
   | 'CrcV1_HubTransfer'
@@ -316,4 +322,5 @@ export type CirclesEventType =
   | 'CrcV2_WithdrawDemurraged'
   | 'CrcV2_WithdrawInflationary'
   | 'CrcV2_ERC20WrapperDeployed'
-  | 'CrcV2_DiscountCost';
+  | 'CrcV2_DiscountCost'
+  | 'Crc_UnknownEvent';

--- a/packages/data/src/events/parser.ts
+++ b/packages/data/src/events/parser.ts
@@ -305,7 +305,11 @@ const parseEventValues = (event: CirclesEventType, values: EventValues): Circles
         cost: values.cost ? hexToBigInt(values.cost) : undefined
       };
     default:
-      throw new Error(`Unknown event type: ${event}`);
+      return {
+        ...baseEvent,
+        $event: 'Crc_UnknownEvent',
+        originalEventType: event
+      };
   }
 };
 


### PR DESCRIPTION
The websocket connection is restored in case of an error
- [ ] The websocket connection is restored in case of an error
- [x] The eventParser doesn't throw on unknown events
- [ ] The biconomy adapter is removed

Not so easy wins:
- [ ] A better solution for the adapters and their initialization is found and a follow up issue created for discussion
- [ ] It's decided what happens to the rest of this issue, after above tasks have been completed