### PR TITLE
(CRC-705): sdk improvements

### DIFF
--- a/packages/data/src/circlesRpc.ts
+++ b/packages/data/src/circlesRpc.ts
@@ -16,6 +16,13 @@ export class CirclesRpc {
     [subscriptionId: string]: ((event: { event: string, values: Record<string, any> }[]) => void)[]
   } = {};
 
+  // Backoff-related fields
+  private reconnectAttempt = 0;
+  // Initial backoff delay (ms)
+  private readonly initialBackoff = 2000;
+  // Maximum backoff delay (ms)
+  private readonly maxBackoff = 120000; // 2 mins
+
   constructor(rpcUrl: string) {
     this.rpcUrl = rpcUrl;
   }
@@ -44,8 +51,11 @@ export class CirclesRpc {
     return jsonResponse;
   }
 
+  /**
+   * Initiates a WebSocket connection (or attempts to).
+   */
   private connect() {
-    return new Promise<void>((resolve, reject) => {
+    return new Promise<void>((resolve,) => {
       let wsUrl = this.rpcUrl.replace('http', 'ws');
       if (wsUrl.endsWith('/')) {
         wsUrl += 'ws';
@@ -55,6 +65,10 @@ export class CirclesRpc {
       this.websocket = new WebSocket(wsUrl);
 
       this.websocket.onopen = () => {
+        console.log('WebSocket connected');
+        this.websocketConnected = true;
+        // Reset the reconnect backoff attempts
+        this.reconnectAttempt = 0;
         resolve();
       };
 
@@ -75,13 +89,55 @@ export class CirclesRpc {
         }
       };
       this.websocket.onclose = () => {
+        console.warn('WebSocket closed');
         this.websocketConnected = false;
       };
       this.websocket.onerror = (error) => {
         console.error('WebSocket error:', error);
-        reject(error);
+        this.websocketConnected = false;
+        // Schedule a reconnect
+        this.scheduleReconnect();
       };
     });
+  }
+
+  /**
+   * Schedules a reconnect using exponential backoff with random jitter.
+   */
+  private scheduleReconnect() {
+    // Exponential backoff: 2^attempt * initialBackoff
+    const delay = Math.min(
+      this.initialBackoff * Math.pow(2, this.reconnectAttempt),
+      this.maxBackoff
+    );
+    
+    // Add proportional jitter (between 0% and 50% of the delay)
+    const jitter = delay * (Math.random() * 0.5); // Random value between 0 and 0.5
+    const timeout = delay + jitter;
+
+    console.log(
+      `Reconnecting in ${Math.round(timeout)}ms (attempt #${this.reconnectAttempt + 1})`
+    );
+    this.reconnectAttempt++;
+
+    setTimeout(() => {
+      this.reconnect();
+    }, timeout);
+  }
+
+  /**
+   * Attempts to reconnect the WebSocket by calling `connect()`.
+   */
+  private async reconnect() {
+    if (this.websocketConnected) return; // If it's already connected, do nothing
+    try {
+      await this.connect();
+      console.log('Reconnection successful');
+    } catch (err) {
+      // If connect() fails, schedule a reconnect again
+      console.error('Reconnection attempt failed:', err);
+      this.scheduleReconnect();
+    }
   }
 
   private sendMessage(method: string, params: Record<any, any>, timeout = 5000): Promise<any> {
@@ -107,7 +163,6 @@ export class CirclesRpc {
     address = address?.toLowerCase() as Address;
     if (!this.websocketConnected) {
       await this.connect();
-      this.websocketConnected = true;
     }
     const observable = Observable.create<CirclesEvent>();
     const subscriptionArgs = JSON.stringify(address ? { address } : {});

--- a/packages/data/src/events/events.ts
+++ b/packages/data/src/events/events.ts
@@ -248,6 +248,11 @@ export type CrcV2_DiscountCost = CirclesBaseEvent & {
   cost?: bigint;
 };
 
+export type Crc_UnknownEvent = CirclesBaseEvent & {
+  $event: 'Crc_UnknownEvent';
+  originalEventType: string;
+};
+
 export type CirclesEvent =
   | CrcV1_HubTransfer
   | CrcV1_Signup
@@ -281,7 +286,8 @@ export type CirclesEvent =
   | CrcV2_DepositInflationary
   | CrcV2_WithdrawDemurraged
   | CrcV2_WithdrawInflationary
-  | CrcV2_DiscountCost;
+  | CrcV2_DiscountCost
+  | Crc_UnknownEvent;
 
 export type CirclesEventType =
   | 'CrcV1_HubTransfer'
@@ -316,4 +322,5 @@ export type CirclesEventType =
   | 'CrcV2_WithdrawDemurraged'
   | 'CrcV2_WithdrawInflationary'
   | 'CrcV2_ERC20WrapperDeployed'
-  | 'CrcV2_DiscountCost';
+  | 'CrcV2_DiscountCost'
+  | 'Crc_UnknownEvent';

--- a/packages/data/src/events/parser.ts
+++ b/packages/data/src/events/parser.ts
@@ -305,7 +305,11 @@ const parseEventValues = (event: CirclesEventType, values: EventValues): Circles
         cost: values.cost ? hexToBigInt(values.cost) : undefined
       };
     default:
-      throw new Error(`Unknown event type: ${event}`);
+      return {
+        ...baseEvent,
+        $event: 'Crc_UnknownEvent',
+        originalEventType: event
+      };
   }
 };
 


### PR DESCRIPTION
The websocket connection is restored in case of an error
- [x] The websocket connection is restored in case of an error
- [x] The eventParser doesn't throw on unknown events
- [ ] The biconomy adapter is removed

Not so easy wins:
- [ ] A better solution for the adapters and their initialization is found and a follow up issue created for discussion
- [ ] It's decided what happens to the rest of this issue, after above tasks have been completed