### PR TITLE
fix (CRC-957): recognize migrated org as v2 avatar

### DIFF
--- a/packages/sdk/src/avatar.ts
+++ b/packages/sdk/src/avatar.ts
@@ -108,13 +108,18 @@ export class Avatar implements AvatarInterfaceV2 {
           this._avatar = v2Person();
         } else {
           const v1Avatar = v1Person();
-          const isStopped = await v1Avatar.v1Token?.stopped();
           const isHuman = await v1Avatar.avatarInfo.isHuman;
+
           // Handle edge case: organization migrated to v2 but still have v1 account
           // without token which is recognized as `isStopped == false`
-          this._avatar = isStopped 
-            ? v2Person() 
-            : (isHuman ? v1Person() : v2Person());
+          let isStopped = false;
+          if(isHuman) {
+            isStopped = await v1Avatar.v1Token?.stopped() || false;
+            this._avatar = isStopped ? v2Person() : v1Person();
+          } else {
+            this._avatar = v2Person();
+          }
+
           const avatarInfo = this._avatar.avatarInfo;
           if (avatarInfo) {
             avatarInfo.v1Stopped = isStopped;

--- a/packages/sdk/src/avatar.ts
+++ b/packages/sdk/src/avatar.ts
@@ -109,7 +109,12 @@ export class Avatar implements AvatarInterfaceV2 {
         } else {
           const v1Avatar = v1Person();
           const isStopped = await v1Avatar.v1Token?.stopped();
-          this._avatar = isStopped ? v2Person() : v1Person();
+          const isHuman = await v1Avatar.avatarInfo.isHuman;
+          // Handle edge case: organization migrated to v2 but still have v1 account
+          // without token which is recognized as `isStopped == false`
+          this._avatar = isStopped 
+            ? v2Person() 
+            : (isHuman ? v1Person() : v2Person());
           const avatarInfo = this._avatar.avatarInfo;
           if (avatarInfo) {
             avatarInfo.v1Stopped = isStopped;


### PR DESCRIPTION
The change might be replaced with the conditional statement (`this._avatar = isHuman && !isStopped ? v1Person() : v2Person();`), but the current approach is more readable
