### PR TITLE
Fix (CRC-1023): allow to redeem/mint base group tokens for collateral

### DIFF
--- a/packages/sdk/src/AvatarInterface.ts
+++ b/packages/sdk/src/AvatarInterface.ts
@@ -173,11 +173,20 @@ export interface AvatarInterfaceV2 extends AvatarInterface {
    * Redeems collateral from a group in exchange for the group tokens.
    *
    * @param group - The address of the group to redeem from.
-   * @param collateral - An array of collateral addresses involved in the redemption.
+   * @param collaterals - An array of collateral addresses involved in the redemption.
    * @param amounts - An array of amounts corresponding to the collateral to redeem.
    * @return A promise that resolves to the transaction receipt of the redemption.
    */
-  groupRedeem(group: Address, collateral: Address[], amounts: bigint[]): Promise<ContractTransactionReceipt>;
+  groupRedeem(group: Address, collaterals: Address[], amounts: bigint[]): Promise<ContractTransactionReceipt | TransactionReceipt>;
+
+  /**
+   * Automatically redeems collateral tokens from a Base Group's treasury
+   * 
+   * @param group The address of the Base Group from which to redeem collateral tokens
+   * @param amount The amount of group tokens to redeem for collateral (must be > 0 and <= max redeemable)
+   * @return A Promise resolving to the transaction receipt upon successful automatic redemption
+   */
+  groupRedeemAuto?(group: Address, amount: bigint): Promise<TransactionReceipt>;
 
   /**
    * Wraps ERC115 Circles into demurraged ERC20 Circles.

--- a/packages/sdk/src/avatar.ts
+++ b/packages/sdk/src/avatar.ts
@@ -336,11 +336,28 @@ export class Avatar implements AvatarInterfaceV2 {
    * Facilitates the redemption process for a specified group using the provided collateral and amounts.
    *
    * @param group - The address of the group for which the operation is being performed.
-   * @param collateral - An array of collateral addresses to redeem.
+   * @param collaterals - An array of collateral addresses to redeem.
    * @param amounts - An array of amounts corresponding to each collateral.
    * @returns A promise that resolves to the transaction receipt of the redemption process.
    */
-  groupRedeem = (group: Address, collateral: Address[], amounts: bigint[]): Promise<ContractTransactionReceipt> => this.onlyIfV2((avatar) => avatar.groupRedeem(group, collateral, amounts));
+  groupRedeem = (group: Address, collaterals: Address[], amounts: bigint[]): Promise<ContractTransactionReceipt | TransactionReceipt> => this.onlyIfV2((avatar) => avatar.groupRedeem(group, collaterals, amounts));
+
+  /**
+   * Automatically redeems collateral tokens from a Base Group's treasury
+   * 
+   * @param group The address of the Base Group from which to redeem collateral tokens
+   * @param amount The amount of group tokens to redeem for collateral (must be > 0 and <= max redeemable)
+   * @return A Promise resolving to the transaction receipt upon successful automatic redemption
+   */
+  groupRedeemAuto = (group: Address, amount: bigint): Promise<TransactionReceipt> => {
+    return this.onlyIfV2((avatar) => {
+      if (!avatar.groupRedeemAuto) {
+        throw new Error('groupRedeemAuto method is not implemented');
+      }
+
+      return avatar.groupRedeemAuto(group, amount);
+    });
+  }
 
   /**
    * Wraps the specified amount of personal Circles into demurraged ERC20 tokens for use outside the Circles protocol.

--- a/packages/sdk/src/v2/v2Avatar.ts
+++ b/packages/sdk/src/v2/v2Avatar.ts
@@ -1,6 +1,7 @@
 import { AvatarInterfaceV2 } from '../AvatarInterface';
 import {
   AbiCoder,
+  ContractRunner,
   ContractTransactionReceipt,
   ethers,
   formatEther, keccak256, toUtf8Bytes,
@@ -24,6 +25,7 @@ import {
 import { Profile } from '@circles-sdk/profiles';
 import { TokenType } from '@circles-sdk/data/dist/rows/tokenInfoRow';
 import { BatchRun, TransactionRequest, TransactionResponse } from '@circles-sdk/adapter';
+import { BaseGroup__factory } from '@circles-sdk/abi-v2';
 import { TransferPathStep } from '../pathfinderTypes';
 
 export class V2Avatar implements AvatarInterfaceV2 {
@@ -399,15 +401,66 @@ export class V2Avatar implements AvatarInterfaceV2 {
     return receipt;
   }
 
+  /**
+   * @dev This function enables users to convert personal tokens to group tokens (gCRC)
+   *      For BaseGroup, it sends tokens to the group's BaseMintHandler contract which
+   *      handles the conversion process. For default group types, it calls the Hub's groupMint directly.
+   *      
+   *      The BaseMintHandler works as follows:
+   *      1. It receives ERC1155 tokens via safeBatchTransferFrom
+   *      2. In its onERC1155BatchReceived/onERC1155Received functions, it:
+   *         - Calls the Hub's groupMint function
+   *         - Hub mints the gCRC tokens and sends them back to the BaseMintHandler
+   *         - BaseMintHandler forwards tokens to the beneficiary (or wraps to ERC20 if requested)
+   *      
+   *      The optional `data` parameter can be set to `keccak256("TYPE_DEMURRAGE")` or `keccak256("TYPE_INFLATIONARY")` constants
+   *      to wrap the minted gCRC into specialized ERC20 tokens before returning to the beneficiary.
+   * 
+   * @param group The address of the group
+   * @param collateral An array of collateral token addresses to convert into group tokens
+   * @param amounts An array of amounts to convert, corresponding to each collateral address
+   * @param data Additional data, for BaseGroup can contain token type constants to request ERC20 wrapping
+   * @returns A promise resolving to the transaction receipt after mining
+   */
   async groupMint(group: string, collateral: string[], amounts: bigint[], data: Uint8Array): Promise<ContractTransactionReceipt> {
     this.throwIfV2IsNotAvailable();
-    const tx = await this.sdk.v2Hub!.groupMint(group, collateral, amounts, data);
-    const receipt = await tx.wait();
-    if (!receipt) {
-      throw new Error('Group mint failed');
-    }
 
-    return receipt;
+    group = group.toLowerCase();
+    const groupType = await this.sdk.getGroupType(group as Address);
+
+    if(groupType == "CrcV2_BaseGroupCreated") {
+      const baseGroup = BaseGroup__factory.connect(group, <ContractRunner>this.sdk.contractRunner);
+      
+      // Get Base Group Mint handler address
+      const baseGroupMintHandler = (await baseGroup.BASE_MINT_HANDLER()) ?? ZeroAddress;
+      // Convert collateral tokens addresses to the uint format
+      const collateralIds = collateral.map(collateralId => addressToUInt256(collateralId as Address));
+      // Send tokens to the mint handler
+      const tx = await this.sdk.v2Hub!.safeBatchTransferFrom(
+        this.address,
+        baseGroupMintHandler,
+        collateralIds,
+        amounts,
+        data
+      );
+
+      // Wait on the receipt
+      const receipt = await tx.wait();
+      if (!receipt) {
+        throw new Error('Group mint failed');
+      }
+
+      return receipt;
+    } else {
+      // For the default groups follow use the regular hub groupMint function
+      const tx = await this.sdk.v2Hub!.groupMint(group, collateral, amounts, data);
+      const receipt = await tx.wait();
+      if (!receipt) {
+        throw new Error('Group mint failed');
+      }
+
+      return receipt;
+    }
   }
 
   async getRedeemableAmount(group: Address, collateral: Address): Promise<bigint> {
@@ -497,7 +550,6 @@ export class V2Avatar implements AvatarInterfaceV2 {
         }
       ];
       const sourceCoordinate = flowVertices.indexOf(currentAvatar as Address)
-      console.log(flowVertices, currentAvatar, sourceCoordinate);
 
       // Construct the streams array
       const streams = [

--- a/packages/sdk/src/v2/v2Avatar.ts
+++ b/packages/sdk/src/v2/v2Avatar.ts
@@ -471,16 +471,17 @@ export class V2Avatar implements AvatarInterfaceV2 {
   }
 
   /**
-   * @notice Redeems a specified amount of collateral tokens from a group's treasury
-   * @dev This function allows users to redeem collateral from a group treasury using the appropriate amount of the group tokens.
-   * For CrcV2_BaseGroupCreated groups, it uses the flowMatrix operation,
-   * while for standard groups it uses the ERC1155 safeTransferFrom approach with metadata.
+   * @notice Redeems collateral tokens from a group's treasury in exchange for group tokens
+   * @dev Allows redemption of collateral from group treasuries using equivalent group tokens.
+   * Implementation varies by group type:
+   * - For CrcV2_BaseGroupCreated: Uses flowMatrix operations with vertex coordination
+   * - For standard groups: Uses ERC1155 safeTransferFrom with encoded metadata
    * 
    * @param group The address of the group from which to redeem collateral
-   * @param collateral An array of collateral token addresses to redeem (currently only supports a single token for Base groups)
-   * @param amounts An array of amounts to redeem for each corresponding collateral token (currently only supports a single amount for Base groups)
+   * @param collateral Array of collateral token addresses to redeem
+   * @param amounts Array of collateral amounts to redeem
    * 
-   * @return A Promise resolving to the transaction receipt
+   * @return A Promise resolving to the transaction receipt upon successful redemption
    */
   async groupRedeem(
     group: Address,
@@ -493,36 +494,30 @@ export class V2Avatar implements AvatarInterfaceV2 {
     const groupType = await this.sdk.getGroupType(group);
 
     if(groupType == "CrcV2_BaseGroupCreated") {
-      // @todo implement multicollateral redeem
-      if(collateral.length !== 1 || amounts.length !== 1) {
-        throw new Error('Cannot redeem multiple collaterals');
+      if(collateral.length !== amounts.length) {
+        throw new Error('Collateral and amounts arrays must be the same length');
+      }
+
+      if(!collateral.length || !amounts.length) {
+        throw new Error('Collateral and amounts arrays cannot be empty');
       }
 
       const selectedCollateral = collateral[0].toLowerCase() as Address;
       // Amount to redeem from the group treasury
       const amountToRedeem = amounts[0];
+
+      const totalAmount = amounts.reduce((sum, current) => sum + current, 0n);
+
       // Define the group treasury address
       const treasuryAddress = (await this.sdk.v2Hub!.treasuries(group)).toLowerCase();
       // Address of the redeemer
       const currentAvatar = this.address.toLowerCase();
 
-      // Check if the collateral is trusted by the avatar
-      const isRedeemableCollateralTrusted = await this.trusts(selectedCollateral);
-
-      if(!isRedeemableCollateralTrusted) {
-        throw new Error('Collateral which is gonna be redeemed is not trusted');
-      }
-
-      // Check if treasury has enough collateral
-      const collateralInTreasury = (await this.sdk.v2Hub?.balanceOf(treasuryAddress, BigInt(selectedCollateral))) || 0n;
-
-      if(collateralInTreasury < amountToRedeem) {
-        throw new Error('Insufficient collateral in the group treasury');
-      }
+      // @todo check if the recipient trusts all the collaterals
 
       // Construct the unsorted flow vertices array
       const flowVerticesUnsorted =
-        [selectedCollateral, currentAvatar, group, treasuryAddress]
+        [...collateral, currentAvatar, group, treasuryAddress]
           .map(address => address.toLowerCase());
 
       // Convert to a Set to remove duplicates
@@ -542,20 +537,26 @@ export class V2Avatar implements AvatarInterfaceV2 {
       const flow = [
         {
           streamSinkId: 0,
-          amount: amountToRedeem.toString()
-        },
-        {
-          streamSinkId: 1,
-          amount: amountToRedeem.toString()
+          amount: totalAmount.toString()
         }
       ];
+      const flowEdgeIds: number[] = [];
+      amounts.forEach(amount => {
+        flow.push({
+          streamSinkId: 1,
+          amount: amount.toString()
+        })
+
+        flowEdgeIds.push(flowEdgeIds.length + 1)
+      });
+
       const sourceCoordinate = flowVertices.indexOf(currentAvatar as Address)
 
       // Construct the streams array
       const streams = [
         {
           sourceCoordinate, // Points to sender
-          flowEdgeIds: [1],
+          flowEdgeIds,
           data: "0x"
         }
       ];
@@ -565,14 +566,23 @@ export class V2Avatar implements AvatarInterfaceV2 {
 
       // The packed coordinates based on the example
       let packedCoordinates = "0x";
-      [
+      let coordinates = [
         groupTokenIndex, // token
         sourceCoordinate, // from
-        treasuryIndex, // to
-        collateralIndex, // token
-        treasuryIndex, // from
-        sourceCoordinate // to
-      ].forEach(index => {
+        treasuryIndex // to
+      ]
+
+      collateral.forEach((collateralToken: Address) => {
+        const collateralIndex = flowVertices.indexOf(collateralToken.toLowerCase() as Address);
+
+        coordinates.push(
+          collateralIndex,
+          treasuryIndex,
+          sourceCoordinate
+        );
+      });
+
+      coordinates.forEach((index: number) => {
         // Convert to hex and pad to 4 characters
         const hexValue = index.toString(16).padStart(4, '0');
         packedCoordinates += hexValue;

--- a/packages/sdk/src/v2/v2Avatar.ts
+++ b/packages/sdk/src/v2/v2Avatar.ts
@@ -422,11 +422,11 @@ export class V2Avatar implements AvatarInterfaceV2 {
    * @param data Additional data, for BaseGroup can contain token type constants to request ERC20 wrapping
    * @returns A promise resolving to the transaction receipt after mining
    */
-  async groupMint(group: string, collateral: string[], amounts: bigint[], data: Uint8Array): Promise<ContractTransactionReceipt> {
+  async groupMint(group: Address, collateral: Address[], amounts: bigint[], data: Uint8Array): Promise<ContractTransactionReceipt> {
     this.throwIfV2IsNotAvailable();
 
-    group = group.toLowerCase();
-    const groupType = await this.sdk.getGroupType(group as Address);
+    group = group.toLowerCase() as Address;
+    const groupType = await this.sdk.getGroupType(group);
 
     if(groupType == "CrcV2_BaseGroupCreated") {
       const baseGroup = BaseGroup__factory.connect(group, <ContractRunner>this.sdk.contractRunner);

--- a/packages/sdk/src/v2/v2Avatar.ts
+++ b/packages/sdk/src/v2/v2Avatar.ts
@@ -25,6 +25,7 @@ import {
 import { Profile } from '@circles-sdk/profiles';
 import { TokenType } from '@circles-sdk/data/dist/rows/tokenInfoRow';
 import { BatchRun, TransactionResponse } from '@circles-sdk/adapter';
+import { BaseGroup__factory } from '@circles-sdk/abi-v2';
 import {
   createFlowMatrix, findMaxFlow, findPath, FindPathParams, FlowMatrix,
   getExpectedUnwrappedTokenTotals,

--- a/packages/sdk/src/v2/v2Avatar.ts
+++ b/packages/sdk/src/v2/v2Avatar.ts
@@ -502,10 +502,6 @@ export class V2Avatar implements AvatarInterfaceV2 {
         throw new Error('Collateral and amounts arrays cannot be empty');
       }
 
-      const selectedCollateral = collateral[0].toLowerCase() as Address;
-      // Amount to redeem from the group treasury
-      const amountToRedeem = amounts[0];
-
       const totalAmount = amounts.reduce((sum, current) => sum + current, 0n);
 
       // Define the group treasury address
@@ -513,34 +509,29 @@ export class V2Avatar implements AvatarInterfaceV2 {
       // Address of the redeemer
       const currentAvatar = this.address.toLowerCase();
 
-      // @todo check if the recipient trusts all the collaterals
+      // @todo check if the recipient trusts all collaterals
 
-      // Construct the unsorted flow vertices array
-      const flowVerticesUnsorted =
-        [...collateral, currentAvatar, group, treasuryAddress]
-          .map(address => address.toLowerCase());
-
-      // Convert to a Set to remove duplicates
-      const uniqueAddresses = [...new Set(flowVerticesUnsorted)];
-      
-      // Sort addresses in ascending order based on their numeric value
-      const flowVertices = uniqueAddresses.sort((a, b) => {
+      const flowVertices = [
+        // Convert to a Set to remove duplicates
+        ...new Set([ // Construct the unsorted flow vertices array
+          ...collateral,
+          currentAvatar,
+          group,
+          treasuryAddress
+        ].map(address => address.toLowerCase()))
+      ].sort((a, b) => { // Sort addresses in ascending order based on their numeric value
         const aValue = BigInt(a);
         const bValue = BigInt(b);
-        
+
         if (aValue < bValue) return -1;
         if (aValue > bValue) return 1;
         return 0;
       });
 
       // Construct the flow array
-      const flow = [
-        {
-          streamSinkId: 0,
-          amount: totalAmount.toString()
-        }
-      ];
+      const flow = [{ streamSinkId: 0, amount: totalAmount.toString() }];
       const flowEdgeIds: number[] = [];
+
       amounts.forEach(amount => {
         flow.push({
           streamSinkId: 1,
@@ -551,6 +542,8 @@ export class V2Avatar implements AvatarInterfaceV2 {
       });
 
       const sourceCoordinate = flowVertices.indexOf(currentAvatar as Address)
+      const groupTokenIndex = flowVertices.indexOf(group as Address);
+      const treasuryIndex = flowVertices.indexOf(treasuryAddress as Address);
 
       // Construct the streams array
       const streams = [
@@ -560,17 +553,12 @@ export class V2Avatar implements AvatarInterfaceV2 {
           data: "0x"
         }
       ];
-      const groupTokenIndex = flowVertices.indexOf(group as Address); 
-      const treasuryIndex = flowVertices.indexOf(treasuryAddress as Address);
-      const collateralIndex = flowVertices.indexOf(selectedCollateral as Address);
 
-      // The packed coordinates based on the example
-      let packedCoordinates = "0x";
-      let coordinates = [
+      const coordinates = [
         groupTokenIndex, // token
         sourceCoordinate, // from
         treasuryIndex // to
-      ]
+      ];
 
       collateral.forEach((collateralToken: Address) => {
         const collateralIndex = flowVertices.indexOf(collateralToken.toLowerCase() as Address);
@@ -582,11 +570,10 @@ export class V2Avatar implements AvatarInterfaceV2 {
         );
       });
 
-      coordinates.forEach((index: number) => {
-        // Convert to hex and pad to 4 characters
-        const hexValue = index.toString(16).padStart(4, '0');
-        packedCoordinates += hexValue;
-      });
+      // The packed coordinates
+      const packedCoordinates = '0x' + coordinates
+        .map(index => index.toString(16).padStart(4, '0'))
+        .join('');
 
       // Call the hub's operateFlowMatrix function with the constructed parameters
       const tx = await this.sdk.v2Hub!.operateFlowMatrix(

--- a/packages/sdk/src/v2/v2Avatar.ts
+++ b/packages/sdk/src/v2/v2Avatar.ts
@@ -410,6 +410,25 @@ export class V2Avatar implements AvatarInterfaceV2 {
     return receipt;
   }
 
+  async getRedeemableAmount(group: Address, collateral: Address): Promise<bigint> {
+    // Define the group treasury address
+    const treasuryAddress = (await this.sdk.v2Hub!.treasuries(group)).toLowerCase();
+
+    return (await this.sdk.v2Hub?.balanceOf(treasuryAddress, BigInt(collateral))) || 0n;
+  }
+
+  /**
+   * @notice Redeems a specified amount of collateral tokens from a group's treasury
+   * @dev This function allows users to redeem collateral from a group treasury using the appropriate amount of the group tokens.
+   * For CrcV2_BaseGroupCreated groups, it uses the flowMatrix operation,
+   * while for standard groups it uses the ERC1155 safeTransferFrom approach with metadata.
+   * 
+   * @param group The address of the group from which to redeem collateral
+   * @param collateral An array of collateral token addresses to redeem (currently only supports a single token for Base groups)
+   * @param amounts An array of amounts to redeem for each corresponding collateral token (currently only supports a single amount for Base groups)
+   * 
+   * @return A Promise resolving to the transaction receipt
+   */
   async groupRedeem(
     group: Address,
     collateral: Address[],
@@ -417,68 +436,174 @@ export class V2Avatar implements AvatarInterfaceV2 {
   ): Promise<ContractTransactionReceipt> {
     this.throwIfV2IsNotAvailable();
 
-    const standardTreasury = this.sdk.circlesConfig.standardTreasury;
-    if (!standardTreasury) {
-      throw new Error('No standard treasury address in config.');
+    group = group.toLowerCase() as Address;
+    const groupType = await this.sdk.getGroupType(group);
+
+    if(groupType == "CrcV2_BaseGroupCreated") {
+      // @todo implement multicollateral redeem
+      if(collateral.length !== 1 || amounts.length !== 1) {
+        throw new Error('Cannot redeem multiple collaterals');
+      }
+
+      const selectedCollateral = collateral[0].toLowerCase() as Address;
+      // Amount to redeem from the group treasury
+      const amountToRedeem = amounts[0];
+      // Define the group treasury address
+      const treasuryAddress = (await this.sdk.v2Hub!.treasuries(group)).toLowerCase();
+      // Address of the redeemer
+      const currentAvatar = this.address.toLowerCase();
+
+      // Check if the collateral is trusted by the avatar
+      const isRedeemableCollateralTrusted = await this.trusts(selectedCollateral);
+
+      if(!isRedeemableCollateralTrusted) {
+        throw new Error('Collateral which is gonna be redeemed is not trusted');
+      }
+
+      // Check if treasury has enough collateral
+      const collateralInTreasury = (await this.sdk.v2Hub?.balanceOf(treasuryAddress, BigInt(selectedCollateral))) || 0n;
+
+      if(collateralInTreasury < amountToRedeem) {
+        throw new Error('Insufficient collateral in the group treasury');
+      }
+
+      // Construct the unsorted flow vertices array
+      const flowVerticesUnsorted =
+        [selectedCollateral, currentAvatar, group, treasuryAddress]
+          .map(address => address.toLowerCase());
+
+      // Convert to a Set to remove duplicates
+      const uniqueAddresses = [...new Set(flowVerticesUnsorted)];
+      
+      // Sort addresses in ascending order based on their numeric value
+      const flowVertices = uniqueAddresses.sort((a, b) => {
+        const aValue = BigInt(a);
+        const bValue = BigInt(b);
+        
+        if (aValue < bValue) return -1;
+        if (aValue > bValue) return 1;
+        return 0;
+      });
+
+      // Construct the flow array
+      const flow = [
+        {
+          streamSinkId: 0,
+          amount: amountToRedeem.toString()
+        },
+        {
+          streamSinkId: 1,
+          amount: amountToRedeem.toString()
+        }
+      ];
+      const sourceCoordinate = flowVertices.indexOf(currentAvatar as Address)
+      console.log(flowVertices, currentAvatar, sourceCoordinate);
+
+      // Construct the streams array
+      const streams = [
+        {
+          sourceCoordinate, // Points to sender
+          flowEdgeIds: [1],
+          data: "0x"
+        }
+      ];
+      const groupTokenIndex = flowVertices.indexOf(group as Address); 
+      const treasuryIndex = flowVertices.indexOf(treasuryAddress as Address);
+      const collateralIndex = flowVertices.indexOf(selectedCollateral as Address);
+
+      // The packed coordinates based on the example
+      let packedCoordinates = "0x";
+      [
+        groupTokenIndex, // token
+        sourceCoordinate, // from
+        treasuryIndex, // to
+        collateralIndex, // token
+        treasuryIndex, // from
+        sourceCoordinate // to
+      ].forEach(index => {
+        // Convert to hex and pad to 4 characters
+        const hexValue = index.toString(16).padStart(4, '0');
+        packedCoordinates += hexValue;
+      });
+
+      // Call the hub's operateFlowMatrix function with the constructed parameters
+      const tx = await this.sdk.v2Hub!.operateFlowMatrix(
+        flowVertices,
+        flow,
+        streams,
+        packedCoordinates
+      );
+
+      const receipt = await tx.wait();
+      if (!receipt) {
+        throw new Error('Group redeem failed');
+      }
+
+      return receipt;
+    } else {
+      const standardTreasury = this.sdk.circlesConfig.standardTreasury;
+      if (!standardTreasury) {
+        throw new Error('No standard treasury address in config.');
+      }
+
+      // 1) Sum up requested redemption amounts
+      let totalValue = 0n;
+      for (const val of amounts) {
+        totalValue += val;
+      }
+      if (totalValue === 0n) {
+        throw new Error('Cannot redeem zero amount.');
+      }
+
+      // 2) Encode the "BaseRedemptionPolicy" data:
+      //    struct BaseRedemptionPolicy {
+      //       uint256[] redemptionIds;
+      //       uint256[] redemptionValues;
+      //    }
+      // Convert each collateral address to its numeric ID:
+      const redemptionIds = collateral.map(addr => addressToUInt256(addr));
+      const baseRedemptionPolicyEncoded = AbiCoder.defaultAbiCoder().encode(
+        ['tuple(uint256[] redemptionIds, uint256[] redemptionValues)'],
+        [[redemptionIds, amounts]]
+      );
+
+      // 3) Encode the Metadata struct:
+      //    struct Metadata {
+      //       bytes32 metadataType;
+      //       bytes   metadata;         // must be empty for groupRedeem
+      //       bytes   erc1155UserData;  // your redemption policy
+      //    }
+      const metadataTuple = [
+        this.METADATATYPE_GROUPREDEEM,
+        '0x',                       // empty 'metadata' for groupRedeem
+        baseRedemptionPolicyEncoded
+      ];
+
+      // Encode as a single tuple
+      const metadataEncoded = AbiCoder.defaultAbiCoder().encode(
+        ['tuple(bytes32, bytes, bytes)'],
+        [metadataTuple]
+      );
+
+      // 4) safeTransferFrom(...) to StandardTreasury
+      const groupId = addressToUInt256(group);
+
+      const tx = await this.sdk.v2Hub!.safeTransferFrom(
+        this.address,
+        standardTreasury,
+        groupId,
+        totalValue,
+        metadataEncoded
+      );
+
+      // 5) Wait on the receipt
+      const receipt = await tx.wait();
+      if (!receipt) {
+        throw new Error('Group redeem failed');
+      }
+
+      return receipt;
     }
-
-    // 1) Sum up requested redemption amounts
-    let totalValue = 0n;
-    for (const val of amounts) {
-      totalValue += val;
-    }
-    if (totalValue === 0n) {
-      throw new Error('Cannot redeem zero amount.');
-    }
-
-    // 2) Encode the "BaseRedemptionPolicy" data:
-    //    struct BaseRedemptionPolicy {
-    //       uint256[] redemptionIds;
-    //       uint256[] redemptionValues;
-    //    }
-    // Convert each collateral address to its numeric ID:
-    const redemptionIds = collateral.map(addr => addressToUInt256(addr));
-    const baseRedemptionPolicyEncoded = AbiCoder.defaultAbiCoder().encode(
-      ['tuple(uint256[] redemptionIds, uint256[] redemptionValues)'],
-      [[redemptionIds, amounts]]
-    );
-
-    // 3) Encode the Metadata struct:
-    //    struct Metadata {
-    //       bytes32 metadataType;
-    //       bytes   metadata;         // must be empty for groupRedeem
-    //       bytes   erc1155UserData;  // your redemption policy
-    //    }
-    const metadataTuple = [
-      this.METADATATYPE_GROUPREDEEM,
-      '0x',                       // empty 'metadata' for groupRedeem
-      baseRedemptionPolicyEncoded
-    ];
-
-    // Encode as a single tuple
-    const metadataEncoded = AbiCoder.defaultAbiCoder().encode(
-      ['tuple(bytes32, bytes, bytes)'],
-      [metadataTuple]
-    );
-
-    // 4) safeTransferFrom(...) to StandardTreasury
-    const groupId = addressToUInt256(group);
-
-    const tx = await this.sdk.v2Hub!.safeTransferFrom(
-      this.address,
-      standardTreasury,
-      groupId,
-      totalValue,
-      metadataEncoded
-    );
-
-    // 5) Wait on the receipt
-    const receipt = await tx.wait();
-    if (!receipt) {
-      throw new Error('Group redeem failed');
-    }
-
-    return receipt;
   }
 
   async getProfile(): Promise<Profile | undefined> {

--- a/packages/sdk/src/v2/v2Avatar.ts
+++ b/packages/sdk/src/v2/v2Avatar.ts
@@ -527,27 +527,27 @@ export class V2Avatar implements AvatarInterfaceV2 {
    * - For standard groups: Uses ERC1155 safeTransferFrom with encoded metadata
    * 
    * @param group The address of the group from which to redeem collateral
-   * @param collateral Array of collateral token addresses to redeem
+   * @param collaterals Array of collateral token addresses to redeem
    * @param amounts Array of collateral amounts to redeem
    * 
    * @return A Promise resolving to the transaction receipt upon successful redemption
    */
   async groupRedeem(
     group: Address,
-    collateral: Address[],
+    collaterals: Address[],
     amounts: bigint[]
-  ): Promise<ContractTransactionReceipt> {
+  ): Promise<ContractTransactionReceipt | TransactionReceipt> {
     this.throwIfV2IsNotAvailable();
 
     group = group.toLowerCase() as Address;
     const groupType = await this.sdk.getGroupType(group);
 
     if(groupType == "CrcV2_BaseGroupCreated") {
-      if(collateral.length !== amounts.length) {
+      if(collaterals.length !== amounts.length) {
         throw new Error('Collateral and amounts arrays must be the same length');
       }
 
-      if(!collateral.length || !amounts.length) {
+      if(!collaterals.length || !amounts.length) {
         throw new Error('Collateral and amounts arrays cannot be empty');
       }
 
@@ -558,17 +558,42 @@ export class V2Avatar implements AvatarInterfaceV2 {
       // Address of the redeemer
       const currentAvatar = this.address.toLowerCase();
 
-      // @todo check if the recipient trusts all collaterals
+      // Check if the recipient trusts all collaterals
+      for (const collateral of collaterals) {
+        const isTrusted = await this.trusts(collateral);
+        if (!isTrusted) {
+          throw new Error(`Collateral ${collateral} is not trusted`);
+        }
+      }
+
+      if (!this.sdk?.contractRunner?.sendBatchTransaction) {
+        throw new Error('ContractRunner (or sendBatchTransaction capability) not available');
+      }
+
+      const batch = this.sdk.contractRunner.sendBatchTransaction();
+      // Check if the account is approved as operator
+      const approvalStatus = await this.sdk.v2Hub!.isApprovedForAll(this.address, this.address);
+
+      if (!approvalStatus) {
+        const tx = this.sdk.v2Hub!.interface.encodeFunctionData('setApprovalForAll', [this.address, true]);
+        batch.addTransaction({
+          to: this.sdk.circlesConfig.v2HubAddress!,
+          data: tx,
+          value: 0n
+        });
+      }
 
       const flowVertices = [
         // Convert to a Set to remove duplicates
-        ...new Set([ // Construct the unsorted flow vertices array
-          ...collateral,
+        ...new Set([
+          // Construct the unsorted flow vertices array
+          ...collaterals,
           currentAvatar,
           group,
           treasuryAddress
         ].map(address => address.toLowerCase()))
-      ].sort((a, b) => { // Sort addresses in ascending order based on their numeric value
+      ].sort((a, b) => {
+        // Sort addresses in ascending order based on their numeric value
         const aValue = BigInt(a);
         const bValue = BigInt(b);
 
@@ -585,9 +610,9 @@ export class V2Avatar implements AvatarInterfaceV2 {
         flow.push({
           streamSinkId: 1,
           amount: amount.toString()
-        })
+        });
 
-        flowEdgeIds.push(flowEdgeIds.length + 1)
+        flowEdgeIds.push(flowEdgeIds.length + 1);
       });
 
       const sourceCoordinate = flowVertices.indexOf(currentAvatar as Address)
@@ -609,8 +634,8 @@ export class V2Avatar implements AvatarInterfaceV2 {
         treasuryIndex // to
       ];
 
-      collateral.forEach((collateralToken: Address) => {
-        const collateralIndex = flowVertices.indexOf(collateralToken.toLowerCase() as Address);
+      collaterals.forEach((collateral: Address) => {
+        const collateralIndex = flowVertices.indexOf(collateral.toLowerCase() as Address);
 
         coordinates.push(
           collateralIndex,
@@ -624,20 +649,26 @@ export class V2Avatar implements AvatarInterfaceV2 {
         .map(index => index.toString(16).padStart(4, '0'))
         .join('');
 
-      // Call the hub's operateFlowMatrix function with the constructed parameters
-      const tx = await this.sdk.v2Hub!.operateFlowMatrix(
+      const tx = this.sdk.v2Hub!.interface.encodeFunctionData('operateFlowMatrix', [
         flowVertices,
         flow,
         streams,
         packedCoordinates
-      );
+      ]);
 
-      const receipt = await tx.wait();
+      batch.addTransaction({
+        to: this.sdk.circlesConfig.v2HubAddress!,
+        data: tx,
+        value: 0n
+      });
+
+      // Call the hub's operateFlowMatrix function with the constructed parameters
+      const receipt = await batch.run();
       if (!receipt) {
         throw new Error('Group redeem failed');
       }
 
-      return receipt;
+      return <TransactionReceipt><unknown>(receipt);
     } else {
       const standardTreasury = this.sdk.circlesConfig.standardTreasury;
       if (!standardTreasury) {
@@ -659,7 +690,7 @@ export class V2Avatar implements AvatarInterfaceV2 {
       //       uint256[] redemptionValues;
       //    }
       // Convert each collateral address to its numeric ID:
-      const redemptionIds = collateral.map(addr => addressToUInt256(addr));
+      const redemptionIds = collaterals.map(collateral => addressToUInt256(collateral));
       const baseRedemptionPolicyEncoded = AbiCoder.defaultAbiCoder().encode(
         ['tuple(uint256[] redemptionIds, uint256[] redemptionValues)'],
         [[redemptionIds, amounts]]
@@ -702,6 +733,79 @@ export class V2Avatar implements AvatarInterfaceV2 {
 
       return receipt;
     }
+  }
+  
+  /**
+   * @notice Automatically redeems collateral tokens from a Base Group's treasury
+   * @dev Performs automatic redemption by determining trusted collaterals and using pathfinder for optimal flow.
+   * 
+   * Only supports CrcV2_BaseGroupCreated group types. The function uses the v2 pathfinder to determine
+   * the optimal redemption path and validates that sufficient liquidity exists before attempting redemption.
+   * 
+   * @param group The address of the Base Group from which to redeem collateral tokens
+   * @param amount The amount of group tokens to redeem for collateral (must be > 0 and <= max redeemable)
+   * 
+   * @return A Promise resolving to the transaction receipt upon successful automatic redemption
+   * 
+   */
+  async groupRedeemAuto(
+    group: Address,
+    amount: bigint
+  ): Promise<TransactionReceipt> {
+    this.throwIfV2IsNotAvailable();
+
+    group = group.toLowerCase() as Address;
+    const groupType = await this.sdk.getGroupType(group);
+
+    if (groupType !== "CrcV2_BaseGroupCreated")
+      throw new Error('Only Base Groups support this method');
+
+    // Address of the redeemer
+    const currentAvatar = this.address.toLowerCase() as Address;
+
+    // Define the group treasury address
+    const treasuryAddress = (await this.sdk.v2Hub!.treasuries(group)).toLowerCase();
+
+    // Get list of all tokens in the treasury
+    const treasuryTokens = (await this.sdk.data.getTokenBalances(treasuryAddress as Address))
+      .filter(balance => balance.isErc1155)
+      .map(balance => balance.tokenAddress);
+
+    const trustRelationships = await this.sdk.data.getAggregatedTrustRelations(currentAvatar, 2);
+    // Get list of tokens to expect from pathfinder
+    const expectedToTokens = trustRelationships.filter(trustObject => {
+      if(
+        (trustObject.relation === "mutuallyTrusts" || trustObject.relation === "trusts") &&
+        treasuryTokens.includes(trustObject.objectAvatar)
+      ) return true;
+    }).map(trustObject => trustObject.objectAvatar);
+
+    // Check if enough tokens as amount
+    const getMaxRedeemableAmount = await this.sdk.v2Pathfinder.getMaxFlow(
+      currentAvatar,
+      currentAvatar,
+      false,
+      [group],
+      expectedToTokens
+    );
+
+    if (BigInt(getMaxRedeemableAmount) < amount)
+      throw new Error(`Specified amount ${amount} exceeds max tokens flow ${getMaxRedeemableAmount}`);
+    
+    const receipt = await this.transfer(
+      currentAvatar,
+      amount,
+      undefined,
+      undefined,
+      false,
+      [group],
+      expectedToTokens
+    )
+
+    if (!receipt) {
+      throw new Error('Group redeem failed');
+    }
+    return receipt;
   }
 
   async getProfile(): Promise<Profile | undefined> {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers';
 import multihash from 'multihashes';
-import { Address } from './type';
+import { Address, BaseGroupMintType } from './type';
 
 /**
  * Converts a CIDv0 string to a UInt8Array, stripping the hashing algorithm identifier.
@@ -281,5 +281,21 @@ export function handleTransactionError(e: any): never {
   throw new Error(JSON.stringify(getCustomErrorFragment('Unknown'), null, 2));
 }
 
-export type { Address } from './type';
+// Utility function to generate mint data based on type
+export function generateBaseGroupMintData(mintType: BaseGroupMintType): Uint8Array {
+  switch (mintType) {
+    case 'ERC1155':
+      return new Uint8Array(0);
+    case 'TYPE_INFLATIONARY':
+      const hashTypeInflationary = ethers.keccak256(ethers.toUtf8Bytes("TYPE_INFLATIONARY"));
+      return ethers.getBytes(hashTypeInflationary);
+    case 'TYPE_DEMURRAGE':
+      const hashDemurage = ethers.keccak256(ethers.toUtf8Bytes("TYPE_DEMURRAGE"));
+      return ethers.getBytes(hashDemurage);
+    default:
+      throw new Error(`Unsupported token type: ${mintType}`);
+  }
+}
+
+export { type Address, BaseGroupMintType } from './type';
 export { CirclesConverter } from './circlesConverter';

--- a/packages/utils/src/type.ts
+++ b/packages/utils/src/type.ts
@@ -1,1 +1,8 @@
 export type Address = `0x${string}`;
+
+// Token type enum
+export enum BaseGroupMintType {
+  ERC1155 = 'ERC1155',
+  INFLATIONARY = 'TYPE_INFLATIONARY',
+  DEMURRAGE = 'TYPE_DEMURRAGE'
+}


### PR DESCRIPTION
## Base Group Functionality Support

### Completed Features

- [x] New `groupRedeemAuto` function is introduced which allows to redeem tokens from the group

- [x] Enable `groupRedeem` functionality for Base groups without pathfinder
  - The redeemer must trust all redeemable collaterals (checked within the function)
  - Treasury must have sufficient collateral to fulfill redemptions

- [x] Enable `groupMint` for Base groups using transfer functionality, the function has the same interface to the regular groups  
  - Minting implementation varies by token type:

    **ERC1155 Tokens:**
    ```typescript
    // For ERC1155 tokens, data parameter must be an empty byte array
    await groupMint(
      group, 
      collateral, 
      amounts, 
      new Uint8Array(0)
    )
    ```

    **Inflationary Tokens:**
    ```typescript
    // For Inflationary tokens, data must be constructed as follows
    const inflationaryMintData = generateBaseGroupMintData(BaseGroupMintType.INFLATIONARY);

    await groupMint(
      group, 
      collateral, 
      amounts, 
      inflationaryMintData
    )
    // Use inflationaryMintData as the data parameter
    ```

    **Demurrage Tokens:**
    ```typescript
    // For Demurrage tokens, data must be constructed as follows
    const demurrageData = generateBaseGroupMintData(BaseGroupMintType.DEMURRAGE);
    
    await groupMint(
      group, 
      collateral, 
      amounts, 
      demurrageData
    )
    // Use demurrageData as the data parameter
    ```