### PR TITLE
Add Repo & Issue Reference to NPM

### DIFF
--- a/packages/abi-v1/package.json
+++ b/packages/abi-v1/package.json
@@ -3,6 +3,13 @@
   "version": "0.29.0",
   "description": "",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aboutcircles/circles-sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/aboutcircles/circles-sdk/issues"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/abi-v2/package.json
+++ b/packages/abi-v2/package.json
@@ -3,6 +3,13 @@
   "version": "0.29.0",
   "description": "",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aboutcircles/circles-sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/aboutcircles/circles-sdk/issues"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/adapter-ethers/package.json
+++ b/packages/adapter-ethers/package.json
@@ -3,6 +3,13 @@
   "version": "0.29.0",
   "description": "",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aboutcircles/circles-sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/aboutcircles/circles-sdk/issues"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/adapter-safe-app/package.json
+++ b/packages/adapter-safe-app/package.json
@@ -3,6 +3,13 @@
   "version": "0.29.0",
   "description": "",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aboutcircles/circles-sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/aboutcircles/circles-sdk/issues"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/adapter-safe/package.json
+++ b/packages/adapter-safe/package.json
@@ -3,6 +3,13 @@
   "version": "0.29.0",
   "description": "",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aboutcircles/circles-sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/aboutcircles/circles-sdk/issues"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -3,6 +3,13 @@
   "version": "0.29.0",
   "description": "",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aboutcircles/circles-sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/aboutcircles/circles-sdk/issues"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -3,6 +3,13 @@
   "version": "0.29.0",
   "description": "",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aboutcircles/circles-sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/aboutcircles/circles-sdk/issues"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/pathfinder/package.json
+++ b/packages/pathfinder/package.json
@@ -3,6 +3,13 @@
   "version": "0.29.0",
   "description": "",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aboutcircles/circles-sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/aboutcircles/circles-sdk/issues"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/profiles/package.json
+++ b/packages/profiles/package.json
@@ -3,6 +3,13 @@
   "version": "0.29.0",
   "description": "",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aboutcircles/circles-sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/aboutcircles/circles-sdk/issues"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -3,6 +3,13 @@
   "version": "0.29.0",
   "description": "",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aboutcircles/circles-sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/aboutcircles/circles-sdk/issues"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
There is currently no reference to the github from NPM (see for example www.npmjs.com/package/@circles-sdk/pathfinder). This PR introduces these. 