### PR TITLE
feat: add lossless demurrage->static conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1845,6 +1845,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "dev": true,
@@ -1977,7 +1992,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2086,6 +2103,53 @@
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "license": "MIT"
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -2437,6 +2501,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "dev": true,
@@ -2451,6 +2532,20 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ejs": {
@@ -2511,6 +2606,36 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -2710,7 +2835,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2762,6 +2889,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "7.0.1",
       "dev": true,
@@ -2782,7 +2924,6 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2804,12 +2945,49 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -2850,6 +3028,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "dev": true,
@@ -2861,6 +3051,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hash-base": {
@@ -2885,7 +3114,6 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2960,6 +3188,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "dev": true,
@@ -3013,6 +3253,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3840,6 +4101,15 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/md5.js": {
       "version": "1.3.5",
       "license": "MIT",
@@ -4161,17 +4431,51 @@
       "license": "MIT"
     },
     "node_modules/pbkdf2": {
-      "version": "3.1.2",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
+      "integrity": "sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==",
       "license": "MIT",
       "dependencies": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "~1.1.3",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "=2.0.1",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.11",
+        "to-buffer": "^1.2.0"
       },
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/pbkdf2/node_modules/create-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+      "integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/pbkdf2/node_modules/hash-base": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+      "integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/pbkdf2/node_modules/ripemd160": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+      "integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "node_modules/picocolors": {
@@ -4207,6 +4511,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/prettier": {
@@ -4499,6 +4812,23 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "license": "MIT"
@@ -4734,6 +5064,20 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/to-buffer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
+      "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "dev": true,
@@ -4901,6 +5245,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/typescript": {
@@ -5084,6 +5442,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/wordwrapjs": {
       "version": "4.0.1",
       "dev": true,
@@ -5207,7 +5586,7 @@
     },
     "packages/abi-v1": {
       "name": "@circles-sdk/abi-v1",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
         "ethers": "^6.13.2"
@@ -5218,7 +5597,7 @@
     },
     "packages/abi-v2": {
       "name": "@circles-sdk/abi-v2",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
         "ethers": "^6.13.2"
@@ -5229,7 +5608,7 @@
     },
     "packages/adapter": {
       "name": "@circles-sdk/adapter",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -5237,11 +5616,11 @@
     },
     "packages/adapter-ethers": {
       "name": "@circles-sdk/adapter-ethers",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
-        "@circles-sdk/adapter": "0.29.0",
-        "@circles-sdk/utils": "0.29.0",
+        "@circles-sdk/adapter": "0.29.1",
+        "@circles-sdk/utils": "0.29.1",
         "ethers": "^6.13.2"
       },
       "devDependencies": {
@@ -5250,7 +5629,7 @@
     },
     "packages/adapter-safe": {
       "name": "@circles-sdk/adapter-safe",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
         "@circles-sdk/adapter": "^0.10.0",
@@ -5264,10 +5643,10 @@
     },
     "packages/adapter-safe-app": {
       "name": "@circles-sdk/adapter-safe-app",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
-        "@circles-sdk/adapter": "0.29.0",
+        "@circles-sdk/adapter": "0.29.1",
         "@safe-global/safe-apps-sdk": "^9.1.0"
       },
       "devDependencies": {
@@ -5280,10 +5659,10 @@
     },
     "packages/data": {
       "name": "@circles-sdk/data",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
-        "@circles-sdk/utils": "0.29.0"
+        "@circles-sdk/utils": "0.29.1"
       },
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -5291,12 +5670,12 @@
     },
     "packages/pathfinder": {
       "name": "@circles-sdk/pathfinder",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
-        "@circles-sdk/abi-v2": "0.29.0",
-        "@circles-sdk/data": "0.29.0",
-        "@circles-sdk/utils": "0.29.0",
+        "@circles-sdk/abi-v2": "0.29.1",
+        "@circles-sdk/data": "0.29.1",
+        "@circles-sdk/utils": "0.29.1",
         "ethers": "^6.13.2"
       },
       "devDependencies": {
@@ -5305,10 +5684,10 @@
     },
     "packages/profiles": {
       "name": "@circles-sdk/profiles",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "ISC",
       "dependencies": {
-        "@circles-sdk/utils": "0.29.0"
+        "@circles-sdk/utils": "0.29.1"
       },
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -5316,14 +5695,14 @@
     },
     "packages/sdk": {
       "name": "@circles-sdk/sdk",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
-        "@circles-sdk/abi-v1": "0.29.0",
-        "@circles-sdk/abi-v2": "0.29.0",
-        "@circles-sdk/adapter-ethers": "0.29.0",
-        "@circles-sdk/data": "0.29.0",
-        "@circles-sdk/profiles": "0.29.0",
+        "@circles-sdk/abi-v1": "0.29.1",
+        "@circles-sdk/abi-v2": "0.29.1",
+        "@circles-sdk/adapter-ethers": "0.29.1",
+        "@circles-sdk/data": "0.29.1",
+        "@circles-sdk/profiles": "0.29.1",
         "ethers": "^6.13.2",
         "multihashes": "^4.0.3"
       },
@@ -5334,7 +5713,7 @@
     },
     "packages/utils": {
       "name": "@circles-sdk/utils",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.1.2",

--- a/packages/abi-v1/package.json
+++ b/packages/abi-v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circles-sdk/abi-v1",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/abi-v2/package.json
+++ b/packages/abi-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circles-sdk/abi-v2",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-ethers/package.json
+++ b/packages/adapter-ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circles-sdk/adapter-ethers",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "ethers": "^6.13.2",
-    "@circles-sdk/adapter": "0.29.0",
-    "@circles-sdk/utils": "0.29.0"
+    "@circles-sdk/adapter": "0.29.1",
+    "@circles-sdk/utils": "0.29.1"
   },
   "keywords": [],
   "author": "",

--- a/packages/adapter-safe-app/package.json
+++ b/packages/adapter-safe-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circles-sdk/adapter-safe-app",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",
@@ -17,7 +17,7 @@
     "build": "rollup -c"
   },
   "dependencies": {
-    "@circles-sdk/adapter": "0.29.0",
+    "@circles-sdk/adapter": "0.29.1",
     "@safe-global/safe-apps-sdk": "^9.1.0"
   },
   "keywords": [],

--- a/packages/adapter-safe/package.json
+++ b/packages/adapter-safe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circles-sdk/adapter-safe",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circles-sdk/adapter",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circles-sdk/data",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",
@@ -17,7 +17,7 @@
     "build": "rollup -c"
   },
   "dependencies": {
-    "@circles-sdk/utils": "0.29.0"
+    "@circles-sdk/utils": "0.29.1"
   },
   "keywords": [],
   "author": "",

--- a/packages/pathfinder/package.json
+++ b/packages/pathfinder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circles-sdk/pathfinder",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",
@@ -17,9 +17,9 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@circles-sdk/abi-v2": "0.29.0",
-    "@circles-sdk/utils": "0.29.0",
-    "@circles-sdk/data": "0.29.0",
+    "@circles-sdk/abi-v2": "0.29.1",
+    "@circles-sdk/utils": "0.29.1",
+    "@circles-sdk/data": "0.29.1",
     "ethers": "^6.13.2"
   },
   "devDependencies": {

--- a/packages/profiles/package.json
+++ b/packages/profiles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circles-sdk/profiles",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",
@@ -17,7 +17,7 @@
     "build": "rollup -c"
   },
   "dependencies": {
-    "@circles-sdk/utils": "0.29.0"
+    "@circles-sdk/utils": "0.29.1"
   },
   "keywords": [],
   "author": "",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circles-sdk/sdk",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",
@@ -17,11 +17,11 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@circles-sdk/abi-v1": "0.29.0",
-    "@circles-sdk/abi-v2": "0.29.0",
-    "@circles-sdk/data": "0.29.0",
-    "@circles-sdk/profiles": "0.29.0",
-    "@circles-sdk/adapter-ethers": "0.29.0",
+    "@circles-sdk/abi-v1": "0.29.1",
+    "@circles-sdk/abi-v2": "0.29.1",
+    "@circles-sdk/data": "0.29.1",
+    "@circles-sdk/profiles": "0.29.1",
+    "@circles-sdk/adapter-ethers": "0.29.1",
     "ethers": "^6.13.2",
     "multihashes": "^4.0.3"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circles-sdk/utils",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/src/circlesConverter.ts
+++ b/packages/utils/src/circlesConverter.ts
@@ -64,6 +64,40 @@ export class CirclesConverter {
     return result;
   }
 
+  /** 1.0 in 1 × 10³⁶ representation. */
+  private static readonly ONE_36 =
+    1_000_000_000_000_000_000_000_000_000_000_000_000_000n; // 1e36
+
+  /** 0.93^(1 / 365.25) scaled to 1e36 (rounded half-up). */
+  private static readonly GAMMA_36 =
+    999_801_332_008_598_957_430_613_406_568_191_166n;
+
+  /** 1 / GAMMA scaled to 1e36 (rounded half-up). */
+  private static readonly BETA_36 =
+    1_000_198_707_468_214_629_156_271_489_013_303_962n;
+
+  /** (a · b) / 1e36 – stays inside the 1e36 domain. */
+  private static mul36(a: bigint, b: bigint): bigint {
+    return (a * b) / this.ONE_36;
+  }
+
+  /** Exponentiation for 1e36-scaled factors. */
+  private static pow36(base36: bigint, exp: bigint): bigint {
+    let result = this.ONE_36;
+    let base = base36;
+    let e = exp;
+
+    while (e > 0n) {
+      const isOdd = (e & 1n) === 1n;
+      if (isOdd) {
+        result = this.mul36(result, base);
+      }
+      base = this.mul36(base, base);
+      e >>= 1n;
+    }
+    return result;
+  }
+
 
   // ───────────────────────────── API: human units ─────────────────────────────
 
@@ -119,6 +153,36 @@ export class CirclesConverter {
     nowUnixSeconds: bigint = BigInt(Math.floor(Date.now() / 1000))
   ): bigint {
     return this.inflationaryToDemurrage(staticCircles, this.dayFromTimestamp(nowUnixSeconds));
+  }
+
+  /** Inflationary → demurraged (exact, reversible). */
+  static inflationaryToDemurrageExact(inflationary: bigint, day: bigint): bigint {
+    const factor = this.pow36(this.GAMMA_36, day);
+    return (inflationary * factor) / this.ONE_36;
+  }
+
+  /** Demurraged → inflationary (inverse of the above, exact). */
+  static demurrageToInflationaryExact(demurraged: bigint, day: bigint): bigint {
+    const factor = this.pow36(this.BETA_36, day);
+    return (demurraged * factor) / this.ONE_36;
+  }
+
+  /** Demurraged atto-circles → static atto-circles “today” (loss-less). */
+  static attoCirclesToAttoStaticCirclesExact(
+    demurraged: bigint,
+    nowUnixSeconds: bigint = BigInt(Math.floor(Date.now() / 1000))
+  ): bigint {
+    const day = this.dayFromTimestamp(nowUnixSeconds);
+    return this.demurrageToInflationaryExact(demurraged, day);
+  }
+
+  /** Static atto-circles → demurraged atto-circles “today” (loss-less). */
+  static attoStaticCirclesToAttoCirclesExact(
+    staticCircles: bigint,
+    nowUnixSeconds: bigint = BigInt(Math.floor(Date.now() / 1000))
+  ): bigint {
+    const day = this.dayFromTimestamp(nowUnixSeconds);
+    return this.inflationaryToDemurrageExact(staticCircles, day);
   }
 
   // ───────────────────── utilities for 6‑decimal truncation ───────────────────


### PR DESCRIPTION
Adds lossless ("Exact") variants of the following conversion functions:

* `demurrageToInflationaryExact`
* `inflationaryToDemurrageExact`
* `attoCirclesToAttoStaticCirclesExact`
* `attoStaticCirclesToAttoCirclesExact`

The original (non-"Exact") versions replicate the contract methods' behavior, introducing slight rounding-down errors during conversion. The new "Exact" versions eliminate this issue entirely, making them suitable for frontend scenarios - for example, when users enter token amounts in demurraged units and expect the exact entered amount to be transferred as static CRC without rounding loss.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced highly precise, reversible conversions between inflationary and demurraged values, ensuring lossless accuracy.
  * Added exact conversion methods for atto-circles and static atto-circles, providing improved precision for value transformations.
* **Chores**
  * Updated package versions across multiple modules to 0.29.1 for consistency and dependency alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->