### PR TITLE
feature: add support for maxTransfers filter for the PF requests

### DIFF
--- a/packages/pathfinder/src/pathfinder.ts
+++ b/packages/pathfinder/src/pathfinder.ts
@@ -10,7 +10,8 @@ export interface FindPathParams {
   fromTokens?: Address[],
   toTokens?: Address[],
   excludeFromTokens?: Address[],
-  excludeToTokens?: Address[]
+  excludeToTokens?: Address[],
+  maxTransfers?: number
 }
 
 /**
@@ -26,7 +27,8 @@ export async function findPath(
     fromTokens,
     toTokens,
     excludeFromTokens,
-    excludeToTokens
+    excludeToTokens,
+    maxTransfers = 300
   }: FindPathParams
 ): Promise<PathfindingResult> {
   const res = await new CirclesRpc(rpcUrl).call<PathfindingResult>('circlesV2_findPath', [{
@@ -34,6 +36,7 @@ export async function findPath(
     Sink: to,
     TargetFlow: targetFlow,
     WithWrap: useWrappedBalances,
+    MaxTransfers: maxTransfers,
     FromTokens: fromTokens,
     ToTokens: toTokens,
     ExcludedFromTokens: excludeFromTokens,
@@ -52,7 +55,8 @@ export async function findMaxFlow(
     fromTokens,
     toTokens,
     excludeFromTokens,
-    excludeToTokens
+    excludeToTokens,
+    maxTransfers
   }: Omit<FindPathParams, 'targetFlow'>
 ): Promise<bigint> {
   const targetFlow = '9999999999999999999999999999999999999';
@@ -64,7 +68,8 @@ export async function findMaxFlow(
     fromTokens,
     toTokens,
     excludeFromTokens,
-    excludeToTokens
+    excludeToTokens,
+    maxTransfers
   });
 
   return BigInt(path.maxFlow);

--- a/packages/sdk/src/AvatarInterface.ts
+++ b/packages/sdk/src/AvatarInterface.ts
@@ -38,6 +38,7 @@ export interface AvatarInterface {
    * @param toTokens If specified, makes sure that only the given tokens arrive at the sink.
    * @param excludeFromTokens If specified, makes sure that the given tokens are not used at the source.
    * @param excludeToTokens If specified, makes sure that the given tokens are not used at the sink.
+   * @param maxTransfers The maximum number of transfers to include in the path (default: 300, ~12 MGas). 
    * @returns The maximum amount that can be transferred.
    */
   getMaxTransferableAmount(
@@ -47,7 +48,8 @@ export interface AvatarInterface {
     fromTokens?: Address[],
     toTokens?: Address[],
     excludeFromTokens?: Address[],
-    excludeToTokens?: Address[]): Promise<number>;
+    excludeToTokens?: Address[],
+    maxTransfers?: number): Promise<number>;
 
   /**
    * Transfers Circles to another avatar.
@@ -63,7 +65,8 @@ export interface AvatarInterface {
    * @param toTokens If specified, makes sure that only the given tokens arrive at the sink.
    * @param excludeFromTokens If specified, makes sure that the given tokens are not used at the source.
    * @param excludeToTokens If specified, makes sure that the given tokens are not used at the sink.
-   */
+   * @param maxTransfers The maximum number of transfers to include in the path (default: 300, ~12 MGas).
+  */
   transfer(
     to: Address,
     amount: bigint,
@@ -73,7 +76,9 @@ export interface AvatarInterface {
     fromTokens?: Address[],
     toTokens?: Address[],
     excludeFromTokens?: Address[],
-    excludeToTokens?: Address[]): Promise<TransactionReceipt>;
+    excludeToTokens?: Address[],
+    maxTransfers?: number
+  ): Promise<TransactionReceipt>;
 
   /**
    * Trusts another avatar. Trusting an avatar means you're willing to accept Circles that have been issued by this avatar.

--- a/packages/sdk/src/avatar.ts
+++ b/packages/sdk/src/avatar.ts
@@ -211,10 +211,20 @@ export class Avatar implements AvatarInterfaceV2 {
    * @param useWrappedBalances If wrapped Circles should be considered in the transfers.
    * @param fromTokens If specified, makes sure that only the given tokens are used at the source.
    * @param toTokens If specified, makes sure that only the given tokens arrive at the sink.
+   * @param excludeFromTokens If specified, makes sure that the given tokens are not used at the source.
+   * @param excludeToTokens If specified, makes sure that the given tokens are not used at the sink.
+   * @param maxTransfers The maximum number of transfers to include in the path (default: 300, ~12 MGas).
    * @returns The maximum amount that can be transferred.
    */
-  getMaxTransferableAmount = (to: Address, tokenId?: Address, useWrappedBalances?: boolean, fromTokens?: Address[], toTokens?: Address[]): Promise<number> =>
-    this.onlyIfInitialized(() => this._avatar!.getMaxTransferableAmount(to, tokenId, useWrappedBalances, fromTokens, toTokens));
+  getMaxTransferableAmount = (to: Address, tokenId?: Address, useWrappedBalances?: boolean, fromTokens?: Address[], toTokens?: Address[], excludeFromTokens?: Address[], excludeToTokens?: Address[], maxTransfers?: number): Promise<number> =>
+    this.onlyIfInitialized(() => {
+      // V2 avatars support all parameters
+      if (this._avatarInfo?.version === 2) {
+        return (<AvatarInterfaceV2>this._avatar!).getMaxTransferableAmount(to, tokenId, useWrappedBalances, fromTokens, toTokens, excludeFromTokens, excludeToTokens, maxTransfers);
+      }
+      // V1 avatars only support to and tokenId
+      return this._avatar!.getMaxTransferableAmount(to, tokenId);
+    });
 
   /**
    * Transfers Circles to another avatar.
@@ -228,23 +238,35 @@ export class Avatar implements AvatarInterfaceV2 {
    * @param useWrappedBalances If wrapped Circles should be considered in the transfers.
    * @param fromTokens If specified, makes sure that only the given tokens are used at the source.
    * @param toTokens If specified, makes sure that only the given tokens arrive at the sink.
+   * @param excludeFromTokens If specified, makes sure that the given tokens are not used at the source.
+   * @param excludeToTokens If specified, makes sure that the given tokens are not used at the sink.
+   * @param maxTransfers The maximum number of transfers to include in the path (default: 300, ~12 MGas).
    */
-  transfer(to: Address, amount: number, token?: Address, txData?: Uint8Array, useWrappedBalances?: boolean, fromTokens?: Address[], toTokens?: Address[]): Promise<TransactionReceipt>;
-  transfer(to: Address, amount: bigint, token?: Address, txData?: Uint8Array, useWrappedBalances?: boolean, fromTokens?: Address[], toTokens?: Address[]): Promise<TransactionReceipt>;
-  transfer(to: Address, amount: number | bigint, token?: Address, txData?: Uint8Array, useWrappedBalances?: boolean, fromTokens?: Address[], toTokens?: Address[]): Promise<TransactionReceipt> {
+  transfer(to: Address, amount: number, token?: Address, txData?: Uint8Array, useWrappedBalances?: boolean, fromTokens?: Address[], toTokens?: Address[], excludeFromTokens?: Address[], excludeToTokens?: Address[], maxTransfers?: number): Promise<TransactionReceipt>;
+  transfer(to: Address, amount: bigint, token?: Address, txData?: Uint8Array, useWrappedBalances?: boolean, fromTokens?: Address[], toTokens?: Address[], excludeFromTokens?: Address[], excludeToTokens?: Address[], maxTransfers?: number): Promise<TransactionReceipt>;
+  transfer(to: Address, amount: number | bigint, token?: Address, txData?: Uint8Array, useWrappedBalances?: boolean, fromTokens?: Address[], toTokens?: Address[], excludeFromTokens?: Address[], excludeToTokens?: Address[], maxTransfers?: number): Promise<TransactionReceipt> {
     if (typeof amount === 'number') {
       if (this.avatarInfo?.version === 1) {
         const sendAttoCircles = CirclesConverter.circlesToAttoCircles(amount);
         const sendAttoCrc = CirclesConverter.attoCirclesToAttoCrc(sendAttoCircles, BigInt(Math.floor(Date.now() / 1000)));
 
-        return this.onlyIfInitialized(() => this._avatar!.transfer(to, sendAttoCrc, token, txData, useWrappedBalances, fromTokens, toTokens));
+        // V1 avatars only support basic parameters
+        return this.onlyIfInitialized(() => this._avatar!.transfer(to, sendAttoCrc, token, txData));
       } else {
         const sendAttoCircles = CirclesConverter.circlesToAttoCircles(amount);
 
-        return this.onlyIfInitialized(() => this._avatar!.transfer(to, sendAttoCircles, token, txData, useWrappedBalances, fromTokens, toTokens));
+        // V2 avatars support all parameters
+        return this.onlyIfInitialized(() => (<AvatarInterfaceV2>this._avatar!).transfer(to, sendAttoCircles, token, txData, useWrappedBalances, fromTokens, toTokens, excludeFromTokens, excludeToTokens, maxTransfers));
       }
     }
-    return this.onlyIfInitialized(() => this._avatar!.transfer(to, amount, token, txData, useWrappedBalances, fromTokens, toTokens));
+    // For bigint amounts
+    if (this.avatarInfo?.version === 1) {
+      // V1 avatars only support basic parameters
+      return this.onlyIfInitialized(() => this._avatar!.transfer(to, amount, token, txData));
+    } else {
+      // V2 avatars support all parameters
+      return this.onlyIfInitialized(() => (<AvatarInterfaceV2>this._avatar!).transfer(to, amount, token, txData, useWrappedBalances, fromTokens, toTokens, excludeFromTokens, excludeToTokens, maxTransfers));
+    }
   }
 
   /**

--- a/packages/sdk/src/v2/pathfinderV2.ts
+++ b/packages/sdk/src/v2/pathfinderV2.ts
@@ -19,7 +19,8 @@ export class V2Pathfinder {
     fromTokens?: Address[],
     toTokens?: Address[],
     excludeFromTokens?: Address[],
-    excludeToTokens?: Address[]): Promise<bigint> {
+    excludeToTokens?: Address[],
+    maxTransfers?: number): Promise<bigint> {
     to = to.toLowerCase() as Address;
 
     const result = await findMaxFlow(
@@ -31,7 +32,8 @@ export class V2Pathfinder {
         fromTokens,
         toTokens,
         excludeFromTokens,
-        excludeToTokens
+        excludeToTokens,
+        maxTransfers
       });
 
     return CirclesConverter.truncateToSixDecimals(result);
@@ -45,7 +47,8 @@ export class V2Pathfinder {
     fromTokens?: Address[],
     toTokens?: Address[],
     excludeFromTokens?: Address[],
-    excludeToTokens?: Address[]): Promise<PathfindingResult> {
+    excludeToTokens?: Address[],
+    maxTransfers?: number): Promise<PathfindingResult> {
 
     return await findPath(
       this.rpcUrl,
@@ -57,7 +60,8 @@ export class V2Pathfinder {
         fromTokens,
         toTokens,
         excludeFromTokens,
-        excludeToTokens
+        excludeToTokens,
+        maxTransfers
       }
     );
   }

--- a/packages/sdk/src/v2/v2Avatar.ts
+++ b/packages/sdk/src/v2/v2Avatar.ts
@@ -90,7 +90,8 @@ export class V2Avatar implements AvatarInterfaceV2 {
     fromTokens?: Address[],
     toTokens?: Address[],
     excludeFromTokens?: Address[],
-    excludeToTokens?: Address[]): Promise<number> {
+    excludeToTokens?: Address[],
+    maxTransfers?: number): Promise<number> {
     this.throwIfV2IsNotAvailable();
     to = to.toLowerCase() as Address;
 
@@ -116,7 +117,8 @@ export class V2Avatar implements AvatarInterfaceV2 {
         fromTokens,
         toTokens,
         excludeFromTokens,
-        excludeToTokens
+        excludeToTokens,
+        maxTransfers
       });
 
     return CirclesConverter.attoCirclesToCircles(CirclesConverter.truncateToSixDecimals(result));
@@ -184,7 +186,8 @@ export class V2Avatar implements AvatarInterfaceV2 {
     fromTokens?: Address[],
     toTokens?: Address[],
     excludeFromTokens?: Address[],
-    excludeToTokens?: Address[]
+    excludeToTokens?: Address[],
+    maxTransfers?: number
   ) {
     this.throwIfV2IsNotAvailable();
 
@@ -236,7 +239,8 @@ export class V2Avatar implements AvatarInterfaceV2 {
         fromTokens,
         toTokens,
         excludeFromTokens,
-        excludeToTokens
+        excludeToTokens,
+        maxTransfers
       }
     );
 
@@ -457,7 +461,8 @@ export class V2Avatar implements AvatarInterfaceV2 {
     fromTokens?: Address[],
     toTokens?: Address[],
     excludeFromTokens?: Address[],
-    excludeToTokens?: Address[]): Promise<TransactionReceipt> {
+    excludeToTokens?: Address[],
+    maxTransfers?: number): Promise<TransactionReceipt> {
     if (!this.sdk?.contractRunner?.sendBatchTransaction) {
       throw new Error('ContractRunner (or sendBatchTransaction capability) not available');
     }
@@ -497,7 +502,8 @@ export class V2Avatar implements AvatarInterfaceV2 {
         fromTokens,
         toTokens,
         excludeFromTokens,
-        excludeToTokens);
+        excludeToTokens,
+        maxTransfers);
 
       return <TransactionReceipt><unknown>(await batch.run());
     } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional maxTransfers parameter (default 300) to pathfinding and transfer APIs, letting callers cap the number of transfer steps considered.
  * Propagated maxTransfers across avatar and V2 pathfinder flows so limits apply end-to-end while preserving existing behaviour when omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->