### PR TITLE
chore: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Circles SDK
 
+> **⚠️ DEPRECATION NOTICE**
+>
+> This package is deprecated. Please migrate to [@aboutcircles/sdk](https://www.npmjs.com/package/@aboutcircles/sdk).
+>
+> See the [migration guide](https://github.com/aboutcircles/sdk/blob/main/MIGRATION_GUIDE.md) for more information.
+
 The Circles SDK is a TypeScript library designed to simplify the interaction with
 the [Circles V1](https://github.com/circlesUBI/circles-contracts) as well as
 with [Circles V2](https://github.com/aboutcircles/circles-contracts-v2).

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -1,3 +1,10 @@
+// Deprecation warning - show once when module is first imported
+console.warn(
+  '\nDEPRECATION NOTICE:\n' +
+  'This package is deprecated. Please migrate to @aboutcircles/sdk.\n' +
+  'See migration guide: https://github.com/aboutcircles/sdk/blob/main/MIGRATION_GUIDE.md\n'
+);
+
 export { PagedQueryResult } from './pagedQuery/pagedQueryResult';
 export { Cursor } from './pagedQuery/cursor';
 export { CirclesQuery } from './pagedQuery/circlesQuery';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,3 +1,10 @@
+// Deprecation warning - show once when module is first imported
+console.warn(
+  '\nDEPRECATION NOTICE:\n' +
+  'This package is deprecated. Please migrate to @aboutcircles/sdk.\n' +
+  'See migration guide: https://github.com/aboutcircles/sdk/blob/main/MIGRATION_GUIDE.md\n'
+);
+
 export { Avatar } from './avatar';
 export { Observable } from '@circles-sdk/data';
 export { Sdk } from './sdk';


### PR DESCRIPTION
I'd also recommend to add the deprecation notice via npm
`npm deprecate circles-sdk/sdk "This package is deprecated. Please migrate to @aboutcircles/sdk. 
See migration guide: https://github.com/aboutcircles/sdk/blob/main/MIGRATION_GUIDE.md"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded SDK public API with additional avatar, pathfinding and configuration exports for more direct access to functionality.

* **Notices**
  * One-time deprecation warnings added to the SDK and data packages (shown on first import) directing users to migration guidance.

* **Documentation**
  * Deprecation notice inserted at the top of the README with migration guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->