### PR TITLE
fix: restrict GITHUB_TOKEN permissions in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - dev
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add top-level `permissions: contents: read` to `build.yml` workflow
- Limits the default `GITHUB_TOKEN` to read-only scope on `pull_request` triggers
- Prevents exfiltration of write-capable tokens via malicious PR build scripts (HOPR-style attack)

## Context
Without an explicit `permissions:` block, the `GITHUB_TOKEN` gets all default permissions including `contents: write`, `issues: write`, `pull-requests: write`. A malicious PR could modify `package.json` scripts to exfiltrate this token during `npm i`, gaining write access to the repo.

## Test plan
- [ ] Verify CI workflow still passes on this PR (build step should work with read-only token)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow security configuration to apply principle of least privilege, refining permissions settings to restrict repository access scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->